### PR TITLE
New ID to randomize + removed Crisanta figure

### DIFF
--- a/resources/data/Randomizer/item-locations.json
+++ b/resources/data/Randomizer/item-locations.json
@@ -250,6 +250,11 @@
         "originalItem": "FG25"
     },
     {
+        "id": "Z05BZ02.l1",
+        "name": "Sculptor final gift",
+        "originalItem": "Marks[5]"
+    },
+    {
         "id": "Z05BZ04.l0",
         "name": "West city upper house chest",
         "originalItem": "FG16"

--- a/resources/data/Randomizer/items.json
+++ b/resources/data/Randomizer/items.json
@@ -422,12 +422,6 @@
         "count": 1
     },
     {
-        "id": "FG44",
-        "name": "Crisanta",
-        "type": "Figurine",
-        "count": 1
-    },
-    {
         "id": "FG45",
         "name": "Cobijada Mayor",
         "type": "Figurine",

--- a/resources/data/Randomizer/items.json
+++ b/resources/data/Randomizer/items.json
@@ -685,7 +685,7 @@
         "name": "5 Marks of Martyrdom",
         "type": "Marks",
         "progression": false,
-        "count": 6
+        "count": 2
     },
     {
         "id": "Marks[4]",


### PR DESCRIPTION
I removed the Crisanta figurine as this item creates a hardlock situation with the Sculptor if you give QI71 Remembrance of Crisanta (Eviterno's reward) after getting FG44 Crisanta.

For `item-locations.json`
Added the item location of Scultor's final gift
`Z05BZ02.l1	Sculptor final gift	Marks[5]`