### PR TITLE
Update items.json for Wall Climb ability

### DIFF
--- a/resources/data/Randomizer/items.json
+++ b/resources/data/Randomizer/items.json
@@ -653,7 +653,7 @@
         "count": 3
     },
     {
-        "id": "AB44",
+        "id": "AB45",
         "name": "Ivy of Ascension",
         "type": "Ability",
         "progression": true,


### PR DESCRIPTION
Changed `AB44: Vertical Impulse Ability Type Ref` to `AB45: Wall Climb Ability Type Ref` as Ivy of Ascension didn't work in game until I unlocked AB45 with the console.