### PR TITLE
Confessor

### DIFF
--- a/BlasII.Randomizer/Models/ItemLocationExtensions.cs
+++ b/BlasII.Randomizer/Models/ItemLocationExtensions.cs
@@ -14,8 +14,8 @@ public static class ItemLocationExtensions
         if (string.IsNullOrEmpty(location.Flags))
             return true;
 
-        if (location.Flags.Contains('L') && !settings.ShuffleLongQuests)
-            return false;
+        //if (location.Flags.Contains('L') && !settings.ShuffleLongQuests)
+        //    return false;
 
         if (location.Flags.Contains('S') && !settings.ShuffleShops)
             return false;

--- a/BlasII.Randomizer/Patches/ItemPreventionPatches.cs
+++ b/BlasII.Randomizer/Patches/ItemPreventionPatches.cs
@@ -180,6 +180,12 @@ class QuestManager_GetVarBool_Patch
             __result = Main.Randomizer.ItemHandler.IsLocationCollected("Z05BZ01.l0")
                 && Main.Randomizer.ItemHandler.IsLocationCollected("Z05BZ01.l16");
         }
+
+        // Only accept cobijada 9 sisters reward
+        else if (scene == "Z0506" && Enumerable.Range(1, 3).Any(x => quest == $"ST25.UPGRADE{x}_UNLOCKED"))
+        {
+            __result = true;
+        }
     }
 
     private static int OwnedKeys
@@ -253,6 +259,7 @@ class QuestManager_GetVar_Patch
             }
         }
 
+        // Always have confessor flowers active
         else if (scene == "Z05BZ01" && quest == "ST01.GUILT_LEVEL")
         {
             __result = "GUILT_LEVEL_4";

--- a/BlasII.Randomizer/Patches/ItemPreventionPatches.cs
+++ b/BlasII.Randomizer/Patches/ItemPreventionPatches.cs
@@ -173,6 +173,13 @@ class QuestManager_GetVarBool_Patch
         {
             __result = true;
         }
+
+        // Keep confessor alive until flowers are opened
+        else if (scene == "Z05BZ01" && quest == "ST01.CONFESSOR_READYTODIE")
+        {
+            __result = Main.Randomizer.ItemHandler.IsLocationCollected("Z05BZ01.l0")
+                && Main.Randomizer.ItemHandler.IsLocationCollected("Z05BZ01.l16");
+        }
     }
 
     private static int OwnedKeys
@@ -199,7 +206,11 @@ class QuestManager_GetVarInt_Patch
         string scene = CoreCache.Room.CurrentRoom?.Name;
         string quest = Main.Randomizer.GetQuestName(questId, varId);
 
-        // No checks yet
+        // Always keep guilt tracker empty
+        if (scene == "Z05BZ01" && quest == "ST01.GUILT_ACCUMULATED")
+        {
+            __result = 0;
+        }
     }
 }
 
@@ -240,6 +251,11 @@ class QuestManager_GetVar_Patch
             {
                 __result = "WEAPON_ROSARY";
             }
+        }
+
+        else if (scene == "Z05BZ01" && quest == "ST01.GUILT_LEVEL")
+        {
+            __result = "GUILT_LEVEL_4";
         }
     }
 }

--- a/BlasII.Randomizer/Patches/PrieDieuPatches.cs
+++ b/BlasII.Randomizer/Patches/PrieDieuPatches.cs
@@ -5,29 +5,6 @@ using Il2CppPlaymaker.PrieDieu;
 namespace BlasII.Randomizer.Patches;
 
 /// <summary>
-/// Skip giving a prie dieu upgrade when talking to the sisters
-/// </summary>
-[HarmonyPatch(typeof(UpgradePrieDieu), nameof(UpgradePrieDieu.OnEnter))]
-class UpgradePrieDieu_OnEnter_Patch
-{
-    public static bool Prefix(UpgradePrieDieu __instance)
-    {
-        string upgradeName = __instance.prieDieuUpgrade.Value.name;
-
-        if (upgradeName == "TeleportToHUBUpgrade" ||
-            upgradeName == "FervourFillUpgrade" ||
-            upgradeName == "TeleportToAnotherPrieuDieuUpgrade")
-        {
-            ModLog.Warn("Skipping upgrade for " + upgradeName);
-            __instance.Finish();
-            return false;
-        }
-
-        return true;
-    }
-}
-
-/// <summary>
 /// Change what they are checking from owning the upgrade to the flag status
 /// </summary>
 [HarmonyPatch(typeof(IsPrieDieuUpgraded), nameof(IsPrieDieuUpgraded.OnEnter))]
@@ -35,39 +12,9 @@ class IsPrieDieuUpgraded_OnEnter_Patch
 {
     public static bool Prefix(IsPrieDieuUpgraded __instance)
     {
-        string upgradeName = __instance.prieDieuUpgrade.Value.name;
-        bool unlocked;
-
-        // Instead of checking the prie dieu upgrade, check the flag
-        if (upgradeName == "TeleportToHUBUpgrade")
-        {
-            unlocked = Main.Randomizer.GetQuestBool("ST25", "UPGRADE1_UNLOCKED");
-        }
-        else if (upgradeName == "FervourFillUpgrade")
-        {
-            unlocked = Main.Randomizer.GetQuestBool("ST25", "UPGRADE2_UNLOCKED");
-        }
-        else if (upgradeName == "TeleportToAnotherPrieuDieuUpgrade")
-        {
-            unlocked = Main.Randomizer.GetQuestBool("ST25", "UPGRADE3_UNLOCKED");
-        }
-        else
-        {
-            return true;
-        }
-
-        // If it was one of these three, do special finish
-        if (unlocked)
-        {
-            __instance.Fsm.Event(__instance.yesEvent);
-            __instance.Finish();
-            return false;
-        }
-        else
-        {
-            __instance.Fsm.Event(__instance.noEvent);
-            __instance.Finish();
-            return false;
-        }
+        ModLog.Info($"Skipping prieu dieu upgrade: {__instance.prieDieuUpgrade.Value.name}");
+        __instance.Fsm.Event(__instance.yesEvent);
+        __instance.Finish();
+        return false;
     }
 }

--- a/BlasII.Randomizer/Randomizer.cs
+++ b/BlasII.Randomizer/Randomizer.cs
@@ -101,7 +101,6 @@ public class Randomizer : BlasIIMod, IPersistentMod
 
         if (InputHandler.GetKeyDown("DisplaySettings"))
         {
-            AssetStorage.PlayerStats.AddToCurrentValue(AssetStorage.RangeStats["Guilt"], 10);
             DisplaySettings();
         }
     }

--- a/BlasII.Randomizer/Randomizer.cs
+++ b/BlasII.Randomizer/Randomizer.cs
@@ -13,7 +13,6 @@ using Il2CppTGK.Game.Components.Abilities;
 using Il2CppTGK.Game.Components.Interactables;
 using Il2CppTGK.Game.PopupMessages;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using UnityEngine;
 
@@ -83,10 +82,6 @@ public class Randomizer : BlasIIMod, IPersistentMod
         ItemHandler = new ItemHandler(true
             ? new PoolsItemShuffler(ItemLocationStorage.AsDictionary, ItemStorage.AsDictionary)
             : new DebugShuffler(ItemLocationStorage.AsDictionary, "Censer"));
-
-        //ShuffleTest(new ForwardItemShuffler(), 777, 500);
-        //ShuffleTest(new ReverseItemShuffler(), 777, 500);
-        //ShuffleTest(new PoolsItemShuffler(), 777, 500);
     }
 
     protected override void OnRegisterServices(ModServiceProvider provider)
@@ -131,43 +126,6 @@ public class Randomizer : BlasIIMod, IPersistentMod
             LoadTriggerRemovalRoom("trigger", "SPGEO_INTERACTABLE_GUILLOTINE");
 
         CoreCache.Shop.cachedInstancedShops.Clear();
-    }
-
-    protected override void OnSceneUnloaded(string sceneName)
-    {
-    }
-
-    // Algorithm efficiency
-    // Forward: 500/500 (63.1)
-    // Reverse: 373/500 (27.9)
-    //   Pools: 379/500 (28.0)
-
-    // This is old data before 1.0.0 that allowed false negatives
-    // Initial forward: 500/500 (61.2)
-    // Initial reverse: 490/500 (25.3)
-    private void ShuffleTest(IShuffler shuffler, int initialSeed, int totalTries)
-    {
-        var seedGen = new System.Random(initialSeed);
-        var output = new Dictionary<string, string>();
-        var settings = RandomizerSettings.DEFAULT;
-
-        int successfulTries = 0;
-        double runningTime = 0;
-
-        for (int i = 0; i < totalTries; i++)
-        {
-            int seed = seedGen.Next(1, RandomizerSettings.MAX_SEED + 1);
-            var stopwatch = Stopwatch.StartNew();
-
-            if (shuffler.Shuffle(seed, settings, output))
-            {
-                successfulTries++;
-                runningTime += stopwatch.Elapsed.TotalMilliseconds;
-            }
-        }
-
-        ModLog.Error($"Successful attempts: {successfulTries}/{totalTries}");
-        ModLog.Error($"Average time: {System.Math.Round(runningTime / successfulTries, 1)} ms");
     }
 
     protected override void OnNewGame()
@@ -228,8 +186,6 @@ public class Randomizer : BlasIIMod, IPersistentMod
         CoreCache.UINavigationHelper.ShowPopupMessage(message, false);
     }
 
-    // Special rooms
-
     /// <summary>
     /// Gives the starting equipment, only called if it hasnt already given it
     /// </summary>
@@ -251,6 +207,8 @@ public class Randomizer : BlasIIMod, IPersistentMod
         foreach (var ability in abilities.Select(x => AssetStorage.Abilities[x]))
             CoreCache.AbilitiesUnlockManager.SetAbility(ability, false);
     }
+
+    // Special rooms
 
     /// <summary>
     /// Hide the weapon statues in the display room

--- a/BlasII.Randomizer/Randomizer.cs
+++ b/BlasII.Randomizer/Randomizer.cs
@@ -100,7 +100,10 @@ public class Randomizer : BlasIIMod, IPersistentMod
             return;
 
         if (InputHandler.GetKeyDown("DisplaySettings"))
+        {
+            AssetStorage.PlayerStats.AddToCurrentValue(AssetStorage.RangeStats["Guilt"], 10);
             DisplaySettings();
+        }
     }
 
     protected override void OnSceneLoaded(string sceneName)

--- a/BlasII.Randomizer/Randomizer.cs
+++ b/BlasII.Randomizer/Randomizer.cs
@@ -216,9 +216,10 @@ public class Randomizer : BlasIIMod, IPersistentMod
     {
         foreach (var upgrade in CoreCache.PrieDieuManager.config.upgrades)
         {
-            if (upgrade.name == "TeleportToAnotherPrieuDieuUpgrade" ||
-                upgrade.name == "FervourFillUpgrade")
-                CoreCache.PrieDieuManager.Upgrade(upgrade);
+            if (upgrade.name == "TeleportToHUBUpgrade")
+                continue;
+
+            CoreCache.PrieDieuManager.Upgrade(upgrade);
         }
     }
 

--- a/BlasII.Randomizer/Services/RandomizerMenu.cs
+++ b/BlasII.Randomizer/Services/RandomizerMenu.cs
@@ -1,5 +1,6 @@
 ﻿using BlasII.Framework.Menus;
 using BlasII.Framework.Menus.Options;
+using BlasII.Framework.UI;
 using UnityEngine;
 
 namespace BlasII.Randomizer.Services;
@@ -22,7 +23,7 @@ public class RandomizerMenu : ModMenu
                 LogicType = 1,
                 RequiredKeys = _setRequiredKeys.CurrentOption - 1,
                 StartingWeapon = _setStartingWeapon.CurrentOption - 1,
-                ShuffleLongQuests = _setShuffleLongQuests.Toggled,
+                ShuffleLongQuests = true,
                 ShuffleShops = _setShuffleShops.Toggled,
             };
         }
@@ -31,7 +32,7 @@ public class RandomizerMenu : ModMenu
             _setLogicDifficulty.CurrentOption = 0;
             _setRequiredKeys.CurrentOption = value.RequiredKeys + 1;
             _setStartingWeapon.CurrentOption = value.StartingWeapon + 1;
-            _setShuffleLongQuests.Toggled = value.ShuffleLongQuests;
+            _setShuffleLongQuests.Toggled = true;
             _setShuffleShops.Toggled = value.ShuffleShops;
 
             _setSeed.CurrentValue = string.Empty;
@@ -81,6 +82,19 @@ public class RandomizerMenu : ModMenu
 
         _setSeed = text.CreateOption("Seed", ui, new Vector2(0, 300), "option/seed", true, false, 6);
 
+        UIModder.Create(new RectCreationOptions()
+        {
+            Name = "Temp text",
+            Parent = ui,
+            Position = new Vector2(0, 200),
+        }).AddText(new TextCreationOptions()
+        {
+            Contents = "More options coming in the next update!",
+            Color = Color.cyan,
+            Alignment = Il2CppTMPro.TextAlignmentOptions.Center,
+            FontSize = 40,
+        });
+
         _setLogicDifficulty = arrow.CreateOption("LD", ui, new Vector2(-300, 80), "option/logic", new string[]
         {
             "option/logic/normal",
@@ -107,6 +121,7 @@ public class RandomizerMenu : ModMenu
         });
 
         _setShuffleLongQuests = toggle.CreateOption("SL", ui, new Vector2(150, 70), "option/long");
+        _setShuffleLongQuests.Enabled = false;
 
         _setShuffleShops = toggle.CreateOption("SS", ui, new Vector2(150, -10), "option/shops");
     }


### PR DESCRIPTION
Remove long quests options because:
- Confessor quest is now less tedious
- Cobijada quest only accepts the 9 sisters dialog
- All pd upgrades from the beginning