### PR TITLE
core:  fix invalid item pickup

### DIFF
--- a/BlasII.Randomizer/Handlers/ItemHandler.cs
+++ b/BlasII.Randomizer/Handlers/ItemHandler.cs
@@ -161,16 +161,21 @@ public class ItemHandler
     /// <summary>
     /// Gets the current amount of total items
     /// </summary>
-    public int TotalItemsDisplay => MappedItems
-        .Select(x => Main.Randomizer.ItemLocationStorage[x.Key])
-        .Count(x => x.ContributesPercentage(Main.Randomizer.CurrentSettings));
+    public int TotalItemsDisplay => MappedItems.Keys.Count(CountsTowardPercentage);
 
     /// <summary>
     /// Gets the current amount of collected items
     /// </summary>
-    public int CollectedItemsDisplay => CollectedLocations
-        .Select(x => Main.Randomizer.ItemLocationStorage[x])
-        .Count(x => x.ContributesPercentage(Main.Randomizer.CurrentSettings));
+    public int CollectedItemsDisplay => CollectedLocations.Count(CountsTowardPercentage);
+
+    /// <summary>
+    /// Checks whether a location should be counted in the item percentage
+    /// </summary>
+    private static bool CountsTowardPercentage(string locationId)
+    {
+        return Main.Randomizer.ItemLocationStorage.TryGetValue(locationId, out ItemLocation location)
+            && location.ContributesPercentage(Main.Randomizer.CurrentSettings);
+    }
 
     // Save data
 


### PR DESCRIPTION
## Description
- Found this playing the randomizer with the third sin content.  Any item picked up related to the third sin was invalid and not granted which with a save file in that state essentially prevented the main menu from loading
- Changed to allow any of those item locations that are unknown to be skipped
  - Should support further work if Mea Culpa or The Third Sin were optionally included to be randomized